### PR TITLE
add runtime dependence on tzdata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/0005-Check-for-protobuf-config-based-module.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("orc", max_pin="x.x.x") }}
 
@@ -36,6 +36,9 @@ requirements:
     - libprotobuf
     - lz4-c
     - zstd
+  run:
+    # orc >=2.0.1 will prefer $CONDA_PREFIX/share/zoneinfo for tzdb
+    - tzdata
 
 test:
   commands:


### PR DESCRIPTION
Discussed with orc- & arrow-devs in https://github.com/apache/arrow/pull/41767. Since https://github.com/apache/orc/pull/1882 (released in orc 2.0.1), orc will prefer conda(-forge)'s tzdata if present. It's necessary on windows, but beneficial also on unix (use more up-to-date tzdb, and avoid unnecessary platform divergence).

PTAL @conda-forge/orc 

CC @kou @wgtmac