### PR TITLE
Backport cmake fix

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -23,7 +23,7 @@ libprotobuf:
 lz4_c:
 - '1.10'
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -23,7 +23,7 @@ libprotobuf:
 lz4_c:
 - '1.10'
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -23,7 +23,7 @@ libprotobuf:
 lz4_c:
 - '1.10'
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -25,7 +25,7 @@ lz4_c:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -25,7 +25,7 @@ lz4_c:
 macos_machine:
 - arm64-apple-darwin20.0.0
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ c_stdlib:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge orc_dev
 cxx_compiler:
 - vs2019
 libprotobuf:
@@ -13,7 +13,7 @@ libprotobuf:
 lz4_c:
 - '1.10'
 orc:
-- 2.0.3
+- 2.1.0
 snappy:
 - '1.2'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ Current release info
 Installing orc
 ==============
 
-Installing `orc` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `orc` from the `conda-forge/label/orc_dev` channel can be achieved by adding `conda-forge/label/orc_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/orc_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `orc` can be installed with `conda`:
+Once the `conda-forge/label/orc_dev` channel has been enabled, `orc` can be installed with `conda`:
 
 ```
 conda install orc
@@ -110,26 +110,26 @@ mamba install orc
 It is possible to list all of the versions of `orc` available on your platform with `conda`:
 
 ```
-conda search orc --channel conda-forge
+conda search orc --channel conda-forge/label/orc_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search orc --channel conda-forge
+mamba search orc --channel conda-forge/label/orc_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search orc --channel conda-forge
+mamba repoquery search orc --channel conda-forge/label/orc_dev
 
 # List packages depending on `orc`:
-mamba repoquery whoneeds orc --channel conda-forge
+mamba repoquery whoneeds orc --channel conda-forge/label/orc_dev
 
 # List dependencies of `orc`:
-mamba repoquery depends orc --channel conda-forge
+mamba repoquery depends orc --channel conda-forge/label/orc_dev
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  conda-forge orc_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   patches:
     - patches/0001-Don-t-force-orc-to-be-a-static-library-let-end-user-.patch
     - patches/0002-Allow-user-to-override-path-to-protoc.patch
+    # backport https://github.com/apache/orc/pull/2108
+    - patches/0003-ORC-1833-C-Fix-CMake-script-to-be-used-inside-anothe.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("orc", max_pin="x.x.x") }}
 

--- a/recipe/patches/0001-Don-t-force-orc-to-be-a-static-library-let-end-user-.patch
+++ b/recipe/patches/0001-Don-t-force-orc-to-be-a-static-library-let-end-user-.patch
@@ -1,7 +1,7 @@
-From da2b1323557fcb0016b4b4b3fe35652c06acaeea Mon Sep 17 00:00:00 2001
+From 2da6a76b50e719d2aec9dd46fb640c524455b1fd Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Fri, 25 Sep 2020 14:49:59 -0400
-Subject: [PATCH 1/2] Don't force orc to be a static library, let end user
+Subject: [PATCH 1/3] Don't force orc to be a static library, let end user
  control it
 
 ---
@@ -21,6 +21,3 @@ index 694667c06..175c032ca 100644
  
  target_link_libraries (orc
    INTERFACE
--- 
-2.47.1
-

--- a/recipe/patches/0002-Allow-user-to-override-path-to-protoc.patch
+++ b/recipe/patches/0002-Allow-user-to-override-path-to-protoc.patch
@@ -1,7 +1,7 @@
-From 68461edc1331b57f1cc130e6c084174de2d88bdd Mon Sep 17 00:00:00 2001
+From 86e901e9e6a035b4bd01a22bd8a48f3dd4443b8a Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 1 Feb 2025 18:53:55 +0000
-Subject: [PATCH 2/2] Allow user to override /path/to/protoc
+Subject: [PATCH 2/3] Allow user to override /path/to/protoc
 
 Useful for cross-compilation
 ---
@@ -24,6 +24,3 @@ index ca91fb5ad..cf02a1199 100644
  
      get_target_property (target_type protobuf::libprotobuf TYPE)
      if (target_type STREQUAL "STATIC_LIBRARY")
--- 
-2.47.1
-

--- a/recipe/patches/0003-ORC-1833-C-Fix-CMake-script-to-be-used-inside-anothe.patch
+++ b/recipe/patches/0003-ORC-1833-C-Fix-CMake-script-to-be-used-inside-anothe.patch
@@ -1,0 +1,456 @@
+From f33bfc050c24a6a78a4e8091370cbaa352391c9d Mon Sep 17 00:00:00 2001
+From: Gang Wu <ustcwg@gmail.com>
+Date: Mon, 13 Jan 2025 21:55:39 +0800
+Subject: [PATCH 3/3] ORC-1833: [C++] Fix CMake script to be used inside
+ another project
+
+### What changes were proposed in this pull request?
+
+The change to add support for exporting CMake config and target has introduced some minor issues when the ORC C++ library is used inside a larger CMake project. Mainly there are three issues:
+
+- We should prepend (not append) our CMake modules so we always use our own modules when there are naming conflict.
+- Do not use CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR because they are tied to the root project and it is no longer ORC project when we are inside another project.
+- Add orc_ prefix to our CMake functions to avoid potential conflict.
+
+See: https://github.com/apache/arrow/pull/45226
+
+### Why are the changes needed?
+
+We had a problem with upgrading Apache ORC to 2.1.0 in the Apache Arrow. See: https://github.com/apache/arrow/pull/45226
+
+### How was this patch tested?
+
+- Pass all CIs.
+- Manually integrated it with Apache Arrow.
+
+### Was this patch authored or co-authored using generative AI tooling?
+
+No.
+
+Closes #2108 from wgtmac/fix_cmake.
+
+Authored-by: Gang Wu <ustcwg@gmail.com>
+Signed-off-by: Gang Wu <ustcwg@gmail.com>
+---
+ CMakeLists.txt                          | 12 +++-
+ c++/src/CMakeLists.txt                  |  6 +-
+ c++/test/CMakeLists.txt                 |  6 +-
+ cmake_modules/CheckFormat.cmake         | 10 ++--
+ cmake_modules/ThirdpartyToolchain.cmake | 76 ++++++++++++-------------
+ tools/src/CMakeLists.txt                |  8 +--
+ tools/test/CMakeLists.txt               | 10 ++--
+ 7 files changed, 67 insertions(+), 61 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1f8931508..e8f894657 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,8 +30,8 @@ SET(CPACK_PACKAGE_VERSION_MAJOR "2")
+ SET(CPACK_PACKAGE_VERSION_MINOR "1")
+ SET(CPACK_PACKAGE_VERSION_PATCH "0")
+ SET(ORC_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # For clang-tidy.
++list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+ 
+ option (BUILD_JAVA
+     "Include ORC Java library in the build process"
+@@ -85,6 +85,10 @@ option(ORC_PACKAGE_KIND
+     "Arbitrary string that identifies the kind of package"
+     "")
+ 
++option(ORC_ENABLE_CLANG_TOOLS
++    "Enable Clang tools"
++    ON)
++
+ # Make sure that a build type is selected
+ if (NOT CMAKE_BUILD_TYPE)
+   message(STATUS "No build type selected, default to ReleaseWithDebugInfo")
+@@ -195,7 +199,7 @@ if (BUILD_ENABLE_AVX512 AND NOT APPLE)
+   INCLUDE(ConfigSimdLevel)
+ endif ()
+ 
+-set (EXAMPLE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples)
++set (EXAMPLE_DIRECTORY ${PROJECT_SOURCE_DIR}/examples)
+ 
+ add_subdirectory(c++)
+ 
+@@ -226,4 +230,6 @@ if (BUILD_CPP_TESTS)
+   endif ()
+ endif ()
+ 
+-INCLUDE(CheckFormat)
++if (ORC_ENABLE_CLANG_TOOLS)
++  INCLUDE(CheckFormat)
++endif ()
+diff --git a/c++/src/CMakeLists.txt b/c++/src/CMakeLists.txt
+index 175c032ca..0c5b39c53 100644
+--- a/c++/src/CMakeLists.txt
++++ b/c++/src/CMakeLists.txt
+@@ -218,11 +218,11 @@ target_include_directories (orc
+   INTERFACE
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   PUBLIC
+-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/c++/include>
+-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/c++/include>
++    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/c++/include>
++    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/c++/include>
+   PRIVATE
+-    ${CMAKE_CURRENT_SOURCE_DIR}
+     ${CMAKE_CURRENT_BINARY_DIR}
++    ${CMAKE_CURRENT_SOURCE_DIR}
+     ${LIBHDFSPP_INCLUDE_DIR}
+ )
+ 
+diff --git a/c++/test/CMakeLists.txt b/c++/test/CMakeLists.txt
+index 6c5b26c4f..f7328abb3 100644
+--- a/c++/test/CMakeLists.txt
++++ b/c++/test/CMakeLists.txt
+@@ -19,9 +19,9 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX17_FLAGS} ${WARN_FLAGS}")
+ 
+ add_library (orc-test-include INTERFACE)
+ target_include_directories (orc-test-include INTERFACE
+-  ${CMAKE_SOURCE_DIR}/c++/src
+-  ${CMAKE_BINARY_DIR}/c++/include
+-  ${CMAKE_BINARY_DIR}/c++/src
++  ${PROJECT_BINARY_DIR}/c++/include
++  ${PROJECT_BINARY_DIR}/c++/src
++  ${PROJECT_SOURCE_DIR}/c++/src
+ )
+ 
+ if(BUILD_ENABLE_AVX512)
+diff --git a/cmake_modules/CheckFormat.cmake b/cmake_modules/CheckFormat.cmake
+index 1aff5d765..17017da13 100644
+--- a/cmake_modules/CheckFormat.cmake
++++ b/cmake_modules/CheckFormat.cmake
+@@ -26,7 +26,7 @@ set(Python3_FIND_FRAMEWORK "LAST")
+ find_package(Python3)
+ set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+ 
+-set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/c++/build-support")
++set(BUILD_SUPPORT_DIR "${PROJECT_SOURCE_DIR}/c++/build-support")
+ 
+ find_program(CLANG_FORMAT_BIN
+         NAMES clang-format-13
+@@ -75,21 +75,21 @@ add_custom_target(check-clang-tidy
+         ${PYTHON_EXECUTABLE}
+         ${BUILD_SUPPORT_DIR}/run_clang_tidy.py # run LLVM's clang-tidy script
+         -clang-tidy-binary ${CLANG_TIDY_BIN} # using our clang-tidy binary
+-        -p ${CMAKE_BINARY_DIR} # using cmake's generated compile commands
++        -p ${PROJECT_BINARY_DIR} # using cmake's generated compile commands
+ )
+ 
+ add_custom_target(fix-clang-tidy
+         ${PYTHON_EXECUTABLE}
+         ${BUILD_SUPPORT_DIR}/run_clang_tidy.py # run LLVM's clang-tidy script
+         -clang-tidy-binary ${CLANG_TIDY_BIN} # using our clang-tidy binary
+-        -p ${CMAKE_BINARY_DIR} # using cmake's generated compile commands
++        -p ${PROJECT_BINARY_DIR} # using cmake's generated compile commands
+         -clang-apply-replacements-binary ${CLANG_APPLY_REPLACEMENTS_BIN} # using our clang-apply-replacements binary
+         -fix # apply suggested changes generated by clang-tidy
+ )
+ 
+ string(CONCAT ORC_FORMAT_DIRS
+-        "${CMAKE_SOURCE_DIR}/c++,"
+-        "${CMAKE_SOURCE_DIR}/tools,"
++        "${PROJECT_SOURCE_DIR}/c++,"
++        "${PROJECT_SOURCE_DIR}/tools,"
+ )
+ 
+ add_custom_target(format 
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index 017e6c5b8..fa5a1c0e1 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -37,7 +37,7 @@ option(ORC_PREFER_STATIC_GMOCK    "Prefer static gmock library, if available"
+ # zstd requires us to add the threads
+ FIND_PACKAGE(Threads REQUIRED)
+ 
+-set(THIRDPARTY_DIR "${CMAKE_BINARY_DIR}/c++/libs/thirdparty")
++set(THIRDPARTY_DIR "${PROJECT_BINARY_DIR}/c++/libs/thirdparty")
+ set(THIRDPARTY_LOG_OPTIONS LOG_CONFIGURE 1
+                            LOG_BUILD 1
+                            LOG_INSTALL 1
+@@ -103,13 +103,13 @@ endif ()
+ 
+ # ----------------------------------------------------------------------
+ # Macros for adding third-party libraries
+-macro (add_resolved_library target_name link_lib include_dir)
+-  add_library (${target_name} INTERFACE IMPORTED)
++macro (orc_add_resolved_library target_name link_lib include_dir)
++  add_library (${target_name} INTERFACE IMPORTED GLOBAL)
+   target_link_libraries (${target_name} INTERFACE ${link_lib})
+   target_include_directories (${target_name} SYSTEM INTERFACE ${include_dir})
+ endmacro ()
+ 
+-macro (add_built_library external_project_name target_name link_lib include_dir)
++macro (orc_add_built_library external_project_name target_name link_lib include_dir)
+   file (MAKE_DIRECTORY "${include_dir}")
+ 
+   add_library (${target_name} STATIC IMPORTED)
+@@ -122,16 +122,16 @@ macro (add_built_library external_project_name target_name link_lib include_dir)
+   endif ()
+ endmacro ()
+ 
+-function(provide_cmake_module MODULE_NAME)
+-  set(module "${CMAKE_SOURCE_DIR}/cmake_modules/${MODULE_NAME}.cmake")
++function(orc_provide_cmake_module MODULE_NAME)
++  set(module "${PROJECT_SOURCE_DIR}/cmake_modules/${MODULE_NAME}.cmake")
+   if(EXISTS "${module}")
+     message(STATUS "Providing CMake module for ${MODULE_NAME} as part of CMake package")
+     install(FILES "${module}" DESTINATION "${ORC_INSTALL_CMAKE_DIR}")
+   endif()
+ endfunction()
+ 
+-function(provide_find_module PACKAGE_NAME)
+-  provide_cmake_module("Find${PACKAGE_NAME}")
++function(orc_provide_find_module PACKAGE_NAME)
++  orc_provide_cmake_module("Find${PACKAGE_NAME}")
+ endfunction()
+ 
+ # ----------------------------------------------------------------------
+@@ -156,7 +156,7 @@ ExternalProject_Add (orc-format_ep
+ # Snappy
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (Snappy REQUIRED CONFIG)
+-  add_resolved_library (orc_snappy ${Snappy_LIBRARIES} ${Snappy_INCLUDE_DIR})
++  orc_add_resolved_library (orc_snappy ${Snappy_LIBRARIES} ${Snappy_INCLUDE_DIR})
+   list (APPEND ORC_SYSTEM_DEPENDENCIES Snappy)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:Snappy::snappy>")
+ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+@@ -168,13 +168,13 @@ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+ elseif (NOT "${SNAPPY_HOME}" STREQUAL "")
+   find_package (Snappy REQUIRED)
+   if (ORC_PREFER_STATIC_SNAPPY AND SNAPPY_STATIC_LIB)
+-    add_resolved_library (orc_snappy ${SNAPPY_STATIC_LIB} ${SNAPPY_INCLUDE_DIR})
++    orc_add_resolved_library (orc_snappy ${SNAPPY_STATIC_LIB} ${SNAPPY_INCLUDE_DIR})
+   else ()
+-    add_resolved_library (orc_snappy ${SNAPPY_LIBRARY} ${SNAPPY_INCLUDE_DIR})
++    orc_add_resolved_library (orc_snappy ${SNAPPY_LIBRARY} ${SNAPPY_INCLUDE_DIR})
+   endif ()
+   list (APPEND ORC_SYSTEM_DEPENDENCIES Snappy)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:Snappy::snappy>")
+-  provide_find_module (Snappy)
++  orc_provide_find_module (Snappy)
+ else ()
+   set(SNAPPY_HOME "${THIRDPARTY_DIR}/snappy_ep-install")
+   set(SNAPPY_INCLUDE_DIR "${SNAPPY_HOME}/include")
+@@ -194,7 +194,7 @@ else ()
+     ${THIRDPARTY_LOG_OPTIONS}
+     BUILD_BYPRODUCTS "${SNAPPY_STATIC_LIB}")
+ 
+-  add_built_library (snappy_ep orc_snappy ${SNAPPY_STATIC_LIB} ${SNAPPY_INCLUDE_DIR})
++  orc_add_built_library (snappy_ep orc_snappy ${SNAPPY_STATIC_LIB} ${SNAPPY_INCLUDE_DIR})
+ 
+   list (APPEND ORC_VENDOR_DEPENDENCIES "orc::vendored_snappy|${SNAPPY_STATIC_LIB_NAME}")
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:orc::vendored_snappy>")
+@@ -207,7 +207,7 @@ add_library (orc::snappy ALIAS orc_snappy)
+ 
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (ZLIB REQUIRED CONFIG)
+-  add_resolved_library (orc_zlib ${ZLIB_LIBRARIES} ${ZLIB_INCLUDE_DIR})
++  orc_add_resolved_library (orc_zlib ${ZLIB_LIBRARIES} ${ZLIB_INCLUDE_DIR})
+   list (APPEND ORC_SYSTEM_DEPENDENCIES ZLIB)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:ZLIB::ZLIB>")
+ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+@@ -219,13 +219,13 @@ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+ elseif (NOT "${ZLIB_HOME}" STREQUAL "")
+   find_package (ZLIB REQUIRED)
+   if (ORC_PREFER_STATIC_ZLIB AND ZLIB_STATIC_LIB)
+-    add_resolved_library (orc_zlib ${ZLIB_STATIC_LIB} ${ZLIB_INCLUDE_DIR})
++    orc_add_resolved_library (orc_zlib ${ZLIB_STATIC_LIB} ${ZLIB_INCLUDE_DIR})
+   else ()
+-    add_resolved_library (orc_zlib ${ZLIB_LIBRARY} ${ZLIB_INCLUDE_DIR})
++    orc_add_resolved_library (orc_zlib ${ZLIB_LIBRARY} ${ZLIB_INCLUDE_DIR})
+   endif ()
+   list (APPEND ORC_SYSTEM_DEPENDENCIES ZLIB)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:ZLIB::ZLIB>")
+-  provide_find_module (ZLIB)
++  orc_provide_find_module (ZLIB)
+ else ()
+   set(ZLIB_PREFIX "${THIRDPARTY_DIR}/zlib_ep-install")
+   set(ZLIB_INCLUDE_DIR "${ZLIB_PREFIX}/include")
+@@ -252,7 +252,7 @@ else ()
+     ${THIRDPARTY_LOG_OPTIONS}
+     BUILD_BYPRODUCTS "${ZLIB_STATIC_LIB}")
+ 
+-  add_built_library (zlib_ep orc_zlib ${ZLIB_STATIC_LIB} ${ZLIB_INCLUDE_DIR})
++  orc_add_built_library (zlib_ep orc_zlib ${ZLIB_STATIC_LIB} ${ZLIB_INCLUDE_DIR})
+ 
+   list (APPEND ORC_VENDOR_DEPENDENCIES "orc::vendored_zlib|${ZLIB_STATIC_LIB_NAME}")
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:orc::vendored_zlib>")
+@@ -265,7 +265,7 @@ add_library (orc::zlib ALIAS orc_zlib)
+ 
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (ZSTD REQUIRED CONFIG)
+-  add_resolved_library (orc_zstd ${zstd_LIBRARIES} ${zstd_INCLUDE_DIR})
++  orc_add_resolved_library (orc_zstd ${zstd_LIBRARIES} ${zstd_INCLUDE_DIR})
+   list (APPEND ORC_SYSTEM_DEPENDENCIES ZSTD)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>>")
+ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+@@ -277,14 +277,14 @@ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+ elseif (NOT "${ZSTD_HOME}" STREQUAL "")
+   find_package (ZSTD REQUIRED)
+   if (ORC_PREFER_STATIC_ZSTD AND ZSTD_STATIC_LIB)
+-    add_resolved_library (orc_zstd ${ZSTD_STATIC_LIB} ${ZSTD_INCLUDE_DIR})
++    orc_add_resolved_library (orc_zstd ${ZSTD_STATIC_LIB} ${ZSTD_INCLUDE_DIR})
+     list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:zstd::libzstd_static>")
+   else ()
+-    add_resolved_library (orc_zstd ${ZSTD_LIBRARY} ${ZSTD_INCLUDE_DIR})
++    orc_add_resolved_library (orc_zstd ${ZSTD_LIBRARY} ${ZSTD_INCLUDE_DIR})
+     list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>>")
+   endif ()
+   list (APPEND ORC_SYSTEM_DEPENDENCIES ZSTD)
+-  provide_find_module (ZSTD)
++  orc_provide_find_module (ZSTD)
+ else ()
+   set(ZSTD_HOME "${THIRDPARTY_DIR}/zstd_ep-install")
+   set(ZSTD_INCLUDE_DIR "${ZSTD_HOME}/include")
+@@ -318,7 +318,7 @@ else ()
+           ${THIRDPARTY_LOG_OPTIONS}
+           BUILD_BYPRODUCTS ${ZSTD_STATIC_LIB})
+ 
+-  add_built_library (zstd_ep orc_zstd ${ZSTD_STATIC_LIB} ${ZSTD_INCLUDE_DIR})
++  orc_add_built_library (zstd_ep orc_zstd ${ZSTD_STATIC_LIB} ${ZSTD_INCLUDE_DIR})
+ 
+   list (APPEND ORC_VENDOR_DEPENDENCIES "orc::vendored_zstd|${ZSTD_STATIC_LIB_NAME}")
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:orc::vendored_zstd>")
+@@ -330,7 +330,7 @@ add_library (orc::zstd ALIAS orc_zstd)
+ # LZ4
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (LZ4 REQUIRED CONFIG)
+-  add_resolved_library (orc_lz4 ${lz4_LIBRARIES} ${lz4_INCLUDE_DIR})
++  orc_add_resolved_library (orc_lz4 ${lz4_LIBRARIES} ${lz4_INCLUDE_DIR})
+   list (APPEND ORC_SYSTEM_DEPENDENCIES LZ4)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:LZ4::lz4>")
+ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+@@ -342,13 +342,13 @@ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+ elseif (NOT "${LZ4_HOME}" STREQUAL "")
+   find_package (LZ4 REQUIRED)
+   if (ORC_PREFER_STATIC_LZ4 AND LZ4_STATIC_LIB)
+-    add_resolved_library (orc_lz4 ${LZ4_STATIC_LIB} ${LZ4_INCLUDE_DIR})
++    orc_add_resolved_library (orc_lz4 ${LZ4_STATIC_LIB} ${LZ4_INCLUDE_DIR})
+   else ()
+-    add_resolved_library (orc_lz4 ${LZ4_LIBRARY} ${LZ4_INCLUDE_DIR})
++    orc_add_resolved_library (orc_lz4 ${LZ4_LIBRARY} ${LZ4_INCLUDE_DIR})
+   endif ()
+   list (APPEND ORC_SYSTEM_DEPENDENCIES LZ4)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:LZ4::lz4>")
+-  provide_find_module (LZ4)
++  orc_provide_find_module (LZ4)
+ else ()
+   set(LZ4_PREFIX "${THIRDPARTY_DIR}/lz4_ep-install")
+   set(LZ4_INCLUDE_DIR "${LZ4_PREFIX}/include")
+@@ -375,7 +375,7 @@ else ()
+     ${THIRDPARTY_LOG_OPTIONS}
+     BUILD_BYPRODUCTS ${LZ4_STATIC_LIB})
+ 
+-  add_built_library (lz4_ep orc_lz4 ${LZ4_STATIC_LIB} ${LZ4_INCLUDE_DIR})
++  orc_add_built_library (lz4_ep orc_lz4 ${LZ4_STATIC_LIB} ${LZ4_INCLUDE_DIR})
+ 
+   list (APPEND ORC_VENDOR_DEPENDENCIES "orc::vendored_lz4|${LZ4_STATIC_LIB_NAME}")
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:orc::vendored_lz4>")
+@@ -491,7 +491,7 @@ endif ()
+ 
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (Protobuf REQUIRED CONFIG)
+-  add_resolved_library (orc_protobuf ${protobuf_LIBRARIES} ${protobuf_INCLUDE_DIR})
++  orc_add_resolved_library (orc_protobuf ${protobuf_LIBRARIES} ${protobuf_INCLUDE_DIR})
+   list (APPEND ORC_SYSTEM_DEPENDENCIES Protobuf)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:protobuf::libprotobuf>")
+ elseif (ORC_PACKAGE_KIND STREQUAL "vcpkg")
+@@ -505,20 +505,20 @@ elseif (NOT "${PROTOBUF_HOME}" STREQUAL "")
+   find_package (Protobuf REQUIRED)
+ 
+   if (ORC_PREFER_STATIC_PROTOBUF AND PROTOBUF_STATIC_LIB)
+-    add_resolved_library (orc_protobuf ${PROTOBUF_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
++    orc_add_resolved_library (orc_protobuf ${PROTOBUF_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
+   else ()
+-    add_resolved_library (orc_protobuf ${PROTOBUF_LIBRARY} ${PROTOBUF_INCLUDE_DIR})
++    orc_add_resolved_library (orc_protobuf ${PROTOBUF_LIBRARY} ${PROTOBUF_INCLUDE_DIR})
+   endif ()
+ 
+   if (ORC_PREFER_STATIC_PROTOBUF AND PROTOC_STATIC_LIB)
+-    add_resolved_library (orc_protoc ${PROTOC_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
++    orc_add_resolved_library (orc_protoc ${PROTOC_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
+   else ()
+-    add_resolved_library (orc_protoc ${PROTOC_LIBRARY} ${PROTOBUF_INCLUDE_DIR})
++    orc_add_resolved_library (orc_protoc ${PROTOC_LIBRARY} ${PROTOBUF_INCLUDE_DIR})
+   endif ()
+ 
+   list (APPEND ORC_SYSTEM_DEPENDENCIES Protobuf)
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:protobuf::libprotobuf>")
+-  provide_find_module (Protobuf)
++  orc_provide_find_module (Protobuf)
+ else ()
+   set(PROTOBUF_PREFIX "${THIRDPARTY_DIR}/protobuf_ep-install")
+   set(PROTOBUF_INCLUDE_DIR "${PROTOBUF_PREFIX}/include")
+@@ -556,8 +556,8 @@ else ()
+     ${THIRDPARTY_LOG_OPTIONS}
+     BUILD_BYPRODUCTS "${PROTOBUF_STATIC_LIB}" "${PROTOC_STATIC_LIB}")
+ 
+-  add_built_library (protobuf_ep orc_protobuf ${PROTOBUF_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
+-  add_built_library (protobuf_ep orc_protoc ${PROTOC_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
++  orc_add_built_library (protobuf_ep orc_protobuf ${PROTOBUF_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
++  orc_add_built_library (protobuf_ep orc_protoc ${PROTOC_STATIC_LIB} ${PROTOBUF_INCLUDE_DIR})
+ 
+   list (APPEND ORC_VENDOR_DEPENDENCIES "orc::vendored_protobuf|${PROTOBUF_STATIC_LIB_NAME}")
+   list (APPEND ORC_INSTALL_INTERFACE_TARGETS "$<INSTALL_INTERFACE:orc::vendored_protobuf>")
+@@ -583,7 +583,7 @@ if(BUILD_LIBHDFSPP)
+       set (LIBHDFSPP_INCLUDE_DIR "${LIBHDFSPP_PREFIX}/include")
+       set (LIBHDFSPP_STATIC_LIB_NAME hdfspp_static)
+       set (LIBHDFSPP_STATIC_LIB "${LIBHDFSPP_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${LIBHDFSPP_STATIC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+-      set (LIBHDFSPP_SRC_URL "${CMAKE_SOURCE_DIR}/c++/libs/libhdfspp/libhdfspp.tar.gz")
++      set (LIBHDFSPP_SRC_URL "${PROJECT_SOURCE_DIR}/c++/libs/libhdfspp/libhdfspp.tar.gz")
+       set (LIBHDFSPP_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                                 -DCMAKE_INSTALL_PREFIX=${LIBHDFSPP_PREFIX}
+                                 -DPROTOBUF_INCLUDE_DIR=${PROTOBUF_INCLUDE_DIR}
+@@ -610,7 +610,7 @@ if(BUILD_LIBHDFSPP)
+         BUILD_BYPRODUCTS "${LIBHDFSPP_STATIC_LIB}"
+         CMAKE_ARGS ${LIBHDFSPP_CMAKE_ARGS})
+ 
+-      add_built_library(libhdfspp_ep libhdfspp ${LIBHDFSPP_STATIC_LIB} ${LIBHDFSPP_INCLUDE_DIR})
++      orc_add_built_library(libhdfspp_ep libhdfspp ${LIBHDFSPP_STATIC_LIB} ${LIBHDFSPP_INCLUDE_DIR})
+ 
+       set (LIBHDFSPP_LIBRARIES
+            libhdfspp
+diff --git a/tools/src/CMakeLists.txt b/tools/src/CMakeLists.txt
+index 32d6eee3d..d247f900e 100644
+--- a/tools/src/CMakeLists.txt
++++ b/tools/src/CMakeLists.txt
+@@ -38,10 +38,10 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${CXX17_FLAGS} ${WARN_FLAGS}")
+ 
+ add_library (orc-tools-common INTERFACE)
+ target_include_directories (orc-tools-common INTERFACE
+-  ${CMAKE_SOURCE_DIR}/c++/include
+-  ${CMAKE_BINARY_DIR}/c++/include
+-  ${CMAKE_SOURCE_DIR}/c++/src
+-  ${CMAKE_BINARY_DIR}/c++/src
++  ${PROJECT_BINARY_DIR}/c++/include
++  ${PROJECT_BINARY_DIR}/c++/src
++  ${PROJECT_SOURCE_DIR}/c++/include
++  ${PROJECT_SOURCE_DIR}/c++/src
+ )
+ target_link_libraries (orc-tools-common INTERFACE
+   orc
+diff --git a/tools/test/CMakeLists.txt b/tools/test/CMakeLists.txt
+index 6e0c6b20b..ed67b4007 100644
+--- a/tools/test/CMakeLists.txt
++++ b/tools/test/CMakeLists.txt
+@@ -38,11 +38,11 @@ target_link_libraries (tool-test
+ )
+ 
+ target_include_directories(tool-test PRIVATE
+-  ${CMAKE_SOURCE_DIR}/c++/include
+-  ${CMAKE_SOURCE_DIR}/c++/src
+-  ${CMAKE_SOURCE_DIR}/tools-c++/src
+-  ${CMAKE_BINARY_DIR}/c++/include
+-  ${CMAKE_BINARY_DIR}/c++/src
++  ${PROJECT_BINARY_DIR}/c++/include
++  ${PROJECT_BINARY_DIR}/c++/src
++  ${PROJECT_SOURCE_DIR}/c++/include
++  ${PROJECT_SOURCE_DIR}/c++/src
++  ${PROJECT_SOURCE_DIR}/tools-c++/src
+ )
+ 
+ add_dependencies(tool-test tool-set)


### PR DESCRIPTION
Backport https://github.com/apache/orc/commit/3eb423ae861d5bcf28fe365f985972aaa08eee35 without publishing it to the main channel yet; in order to test whether the fix is suitable for https://github.com/conda-forge/arrow-cpp-feedstock/pull/1697